### PR TITLE
Feature/replace nan

### DIFF
--- a/ensenso_camera/documentation/release-notes/latest.md
+++ b/ensenso_camera/documentation/release-notes/latest.md
@@ -1,6 +1,7 @@
 # New features
 
 * Added boolean variable to replace the NaN values of a point cloud with a constant.
+* The camera intrinsics of the monocular camera are retrieved as result of the request_data action call.
 
 # Bug fixes
 

--- a/ensenso_camera/documentation/release-notes/latest.md
+++ b/ensenso_camera/documentation/release-notes/latest.md
@@ -1,5 +1,7 @@
 # New features
 
+* Added boolean variable to replace the NaN values of a point cloud with a constant.
+
 # Bug fixes
 
 * The camera instrinsics matrix is changed to the values of the dynamic calibration when capturing the first image. Therefore, when requesting the camera info it is this matrix that should be returned and not the "static calibration matrix". 

--- a/ensenso_camera/include/ensenso_camera/camera.h
+++ b/ensenso_camera/include/ensenso_camera/camera.h
@@ -129,6 +129,7 @@ private:
 
   sensor_msgs::CameraInfoPtr leftCameraInfo;
   sensor_msgs::CameraInfoPtr rightCameraInfo;
+  sensor_msgs::CameraInfoPtr linkedCameraInfo;
   sensor_msgs::CameraInfoPtr leftRectifiedCameraInfo;
   sensor_msgs::CameraInfoPtr rightRectifiedCameraInfo;
   sensor_msgs::PointCloud2 pointCloudMessage;
@@ -367,8 +368,21 @@ private:
    *                                of the left one.
    * @param use_dynamic_calibration Whether the calibration should be read
    *                                from the dynamic calibration
+   * @param rectified               If matrices concern rectified images (no distortion)
+   *                                
    */
   void fillCameraInfoFromNxLib(sensor_msgs::CameraInfoPtr const& info, bool right, bool use_dynamic_calibration, bool rectified = false) const;
+
+  /**
+   * Read the linked camera calibration from the NxLib and write it into a CameraInfo
+   * message.
+   *
+   * @param info                    The CameraInfo message to which the calibration should be
+   *                                written.
+   */
+  void fillLinkedCameraInfoFromNxLib(sensor_msgs::CameraInfoPtr const& info) const;
+
+
   /**
    * Update the cached CameraInfo messages that will be published together
    * with the images.

--- a/ensenso_camera/include/ensenso_camera/point_cloud_utilities.h
+++ b/ensenso_camera/include/ensenso_camera/point_cloud_utilities.h
@@ -39,7 +39,7 @@ struct PointCloudROI
  * Convert the given binary NxLib node to a PCL point cloud.
  */
 pcl::PointCloud<pcl::PointXYZ>::Ptr pointCloudFromNxLib(NxLibItem const& node, std::string const& frame,
-                                                        PointCloudROI const* roi = 0);
+                                                        PointCloudROI const* roi = 0, bool const replace_nan = false);
 
 /**
  * Convert the given binary NxLib node to an RGBD image.

--- a/ensenso_camera/src/camera.cpp
+++ b/ensenso_camera/src/camera.cpp
@@ -870,7 +870,7 @@ void Camera::handleLinkedCameraRequestData(ensenso_camera_msgs::RequestDataGoalC
       }
 
       // Get point cloud in the correct format and publish it. This point cloud in the frame of the depth camera
-      auto pointCloud = pointCloudFromNxLib(rootNode[itmImages][itmRenderPointMap], targetFrame, pointCloudROI);
+      auto pointCloud = pointCloudFromNxLib(rootNode[itmImages][itmRenderPointMap], targetFrame, pointCloudROI, true);
       pcl::toROSMsg(*pointCloud, result.registered_point_cloud);
       auto publishLinkedPointCloudEndTime = std::chrono::high_resolution_clock::now();
 

--- a/ensenso_camera/src/point_cloud_utilities.cpp
+++ b/ensenso_camera/src/point_cloud_utilities.cpp
@@ -33,8 +33,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr pointCloudFromNxLib(NxLibItem const& node, s
 
   for (int i = 0; i < width * height; i++)
   {
-      // NAN should be replaced by -1000 as reques
-      float nan_constant = -1000.0;
 
       if(replace_nan && std::isnan(data[i * 3]))
       {

--- a/ensenso_camera_msgs/action/RequestData.action
+++ b/ensenso_camera_msgs/action/RequestData.action
@@ -61,6 +61,7 @@ sensor_msgs/Image[] left_raw_images
 sensor_msgs/Image[] right_raw_images
 sensor_msgs/CameraInfo left_camera_info
 sensor_msgs/CameraInfo right_camera_info
+sensor_msgs/CameraInfo linked_camera_info
 
 # The rectified images of the left and right camera respectively. A single image
 # if FlexView is disabled.


### PR DESCRIPTION
. As requested by Fizyr, NaN should be encoded as -10000
. The linked camera intrinsics are made available with request data action